### PR TITLE
添加其他平台的编译支持

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ default = []
 # Implement sbi-rt traits for integer types
 # By using this feature, parameter types of sbi-rt functions fall back to integers,
 # static type checks are disabled so this library won't detect parameters in incorrect orders.
-# Although some people may find it userul in prototyping sbi-rt implementations,
+# Although some people may find it useful in prototyping sbi-rt implementations,
 # users of this crate are strongly encouraged not to enable this feature in production.
 integer-impls = []
 # Support legacy extension; this feature is not included by default.

--- a/src/binary.rs
+++ b/src/binary.rs
@@ -4,63 +4,95 @@ pub use sbi_spec::binary::SbiRet;
 
 #[inline(always)]
 pub(crate) fn sbi_call_0(eid: usize, fid: usize) -> SbiRet {
-    let (error, value);
-    unsafe {
-        core::arch::asm!(
-            "ecall",
-            in("a7") eid,
-            in("a6") fid,
-            lateout("a0") error,
-            lateout("a1") value,
-        );
+    #[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))]
+    {
+        let (error, value);
+        unsafe {
+            core::arch::asm!(
+                "ecall",
+                in("a7") eid,
+                in("a6") fid,
+                lateout("a0") error,
+                lateout("a1") value,
+            );
+        }
+        SbiRet { error, value }
     }
-    SbiRet { error, value }
+    #[cfg(not(any(target_arch = "riscv32", target_arch = "riscv64")))]
+    {
+        let _ = (eid, fid);
+        unimplemented!("not RISC-V instruction set architecture")
+    }
 }
 
 #[inline(always)]
 pub(crate) fn sbi_call_1(eid: usize, fid: usize, arg0: usize) -> SbiRet {
-    let (error, value);
-    unsafe {
-        core::arch::asm!(
-            "ecall",
-            in("a7") eid,
-            in("a6") fid,
-            inlateout("a0") arg0 => error,
-            lateout("a1") value,
-        );
+    #[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))]
+    {
+        let (error, value);
+        unsafe {
+            core::arch::asm!(
+                "ecall",
+                in("a7") eid,
+                in("a6") fid,
+                inlateout("a0") arg0 => error,
+                lateout("a1") value,
+            );
+        }
+        SbiRet { error, value }
     }
-    SbiRet { error, value }
+    #[cfg(not(any(target_arch = "riscv32", target_arch = "riscv64")))]
+    {
+        let _ = (eid, fid, arg0);
+        unimplemented!("not RISC-V instruction set architecture")
+    }
 }
 
 #[inline(always)]
 pub(crate) fn sbi_call_2(eid: usize, fid: usize, arg0: usize, arg1: usize) -> SbiRet {
-    let (error, value);
-    unsafe {
-        core::arch::asm!(
-            "ecall",
-            in("a7") eid,
-            in("a6") fid,
-            inlateout("a0") arg0 => error,
-            inlateout("a1") arg1 => value,
-        );
+    #[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))]
+    {
+        let (error, value);
+        unsafe {
+            core::arch::asm!(
+                "ecall",
+                in("a7") eid,
+                in("a6") fid,
+                inlateout("a0") arg0 => error,
+                inlateout("a1") arg1 => value,
+            );
+        }
+        SbiRet { error, value }
     }
-    SbiRet { error, value }
+    #[cfg(not(any(target_arch = "riscv32", target_arch = "riscv64")))]
+    {
+        let _ = (eid, fid, arg0, arg1);
+        unimplemented!("not RISC-V instruction set architecture")
+    }
 }
 
 #[inline(always)]
 pub(crate) fn sbi_call_3(eid: usize, fid: usize, arg0: usize, arg1: usize, arg2: usize) -> SbiRet {
-    let (error, value);
-    unsafe {
-        core::arch::asm!(
-            "ecall",
-            in("a7") eid,
-            in("a6") fid,
-            inlateout("a0") arg0 => error,
-            inlateout("a1") arg1 => value,
-            in("a2") arg2,
-        );
+    #[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))]
+    {
+        let (error, value);
+        unsafe {
+            core::arch::asm!(
+                "ecall",
+                in("a7") eid,
+                in("a6") fid,
+                inlateout("a0") arg0 => error,
+                inlateout("a1") arg1 => value,
+                in("a2") arg2,
+            );
+        }
+        SbiRet { error, value }
     }
-    SbiRet { error, value }
+    #[cfg(not(any(target_arch = "riscv32", target_arch = "riscv64")))]
+    {
+        let _ = (eid, fid, arg0, arg1, arg2);
+        unimplemented!("not RISC-V instruction set architecture")
+    }
 }
 
 #[inline(always)]
@@ -72,19 +104,27 @@ pub(crate) fn sbi_call_4(
     arg2: usize,
     arg3: usize,
 ) -> SbiRet {
-    let (error, value);
-    unsafe {
-        core::arch::asm!(
-            "ecall",
-            in("a7") eid,
-            in("a6") fid,
-            inlateout("a0") arg0 => error,
-            inlateout("a1") arg1 => value,
-            in("a2") arg2,
-            in("a3") arg3,
-        );
+    #[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))]
+    {
+        let (error, value);
+        unsafe {
+            core::arch::asm!(
+                "ecall",
+                in("a7") eid,
+                in("a6") fid,
+                inlateout("a0") arg0 => error,
+                inlateout("a1") arg1 => value,
+                in("a2") arg2,
+                in("a3") arg3,
+            );
+        }
+        SbiRet { error, value }
     }
-    SbiRet { error, value }
+    #[cfg(not(any(target_arch = "riscv32", target_arch = "riscv64")))]
+    {
+        let _ = (eid, fid, arg0, arg1, arg2, arg3);
+        unimplemented!("not RISC-V instruction set architecture")
+    }
 }
 
 #[inline(always)]
@@ -97,20 +137,28 @@ pub(crate) fn sbi_call_5(
     arg3: usize,
     arg4: usize,
 ) -> SbiRet {
-    let (error, value);
-    unsafe {
-        core::arch::asm!(
-            "ecall",
-            in("a7") eid,
-            in("a6") fid,
-            inlateout("a0") arg0 => error,
-            inlateout("a1") arg1 => value,
-            in("a2") arg2,
-            in("a3") arg3,
-            in("a4") arg4,
-        );
+    #[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))]
+    {
+        let (error, value);
+        unsafe {
+            core::arch::asm!(
+                "ecall",
+                in("a7") eid,
+                in("a6") fid,
+                inlateout("a0") arg0 => error,
+                inlateout("a1") arg1 => value,
+                in("a2") arg2,
+                in("a3") arg3,
+                in("a4") arg4,
+            );
+        }
+        SbiRet { error, value }
     }
-    SbiRet { error, value }
+    #[cfg(not(any(target_arch = "riscv32", target_arch = "riscv64")))]
+    {
+        let _ = (eid, fid, arg0, arg1, arg2, arg3, arg4);
+        unimplemented!("not RISC-V instruction set architecture")
+    }
 }
 
 #[cfg(target_pointer_width = "32")]
@@ -125,19 +173,27 @@ pub(crate) fn sbi_call_6(
     arg4: usize,
     arg5: usize,
 ) -> SbiRet {
-    let (error, value);
-    unsafe {
-        core::arch::asm!(
-            "ecall",
-            in("a7") eid,
-            in("a6") fid,
-            inlateout("a0") arg0 => error,
-            inlateout("a1") arg1 => value,
-            in("a2") arg2,
-            in("a3") arg3,
-            in("a4") arg4,
-            in("a5") arg5,
-        );
+    #[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))]
+    {
+        let (error, value);
+        unsafe {
+            core::arch::asm!(
+                "ecall",
+                in("a7") eid,
+                in("a6") fid,
+                inlateout("a0") arg0 => error,
+                inlateout("a1") arg1 => value,
+                in("a2") arg2,
+                in("a3") arg3,
+                in("a4") arg4,
+                in("a5") arg5,
+            );
+        }
+        SbiRet { error, value }
     }
-    SbiRet { error, value }
+    #[cfg(not(any(target_arch = "riscv32", target_arch = "riscv64")))]
+    {
+        let _ = (eid, fid, arg0, arg1, arg2, arg3, arg4, arg5);
+        unimplemented!("not RISC-V instruction set architecture")
+    }
 }

--- a/src/legacy.rs
+++ b/src/legacy.rs
@@ -89,49 +89,68 @@ pub fn shutdown() -> ! {
 
 #[inline(always)]
 fn sbi_call_legacy_0(eid: usize) -> usize {
-    let error;
+    #[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))]
     unsafe {
+        let error;
         core::arch::asm!(
             "ecall",
             in("a7") eid,
             lateout("a0") error,
         );
+        error
     }
-    error
+    #[cfg(not(any(target_arch = "riscv32", target_arch = "riscv64")))]
+    {
+        let _ = eid;
+        unimplemented!("not RISC-V instruction set architecture")
+    }
 }
 
 #[inline(always)]
 fn sbi_call_legacy_1(eid: usize, arg0: usize) -> usize {
-    let error;
+    #[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))]
     unsafe {
+        let error;
         core::arch::asm!(
             "ecall",
             in("a7") eid,
             inlateout("a0") arg0 => error,
         );
+        error
     }
-    error
+    #[cfg(not(any(target_arch = "riscv32", target_arch = "riscv64")))]
+    {
+        let _ = (eid, arg0);
+        unimplemented!("not RISC-V instruction set architecture")
+    }
 }
 
 #[cfg(target_pointer_width = "32")]
 #[inline(always)]
 fn sbi_call_legacy_2(eid: usize, arg0: usize, arg1: usize) -> usize {
-    let error;
+    #[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))]
     unsafe {
+        let error;
         core::arch::asm!(
             "ecall",
             in("a7") eid,
             inlateout("a0") arg0 => error,
             in("a1") arg1,
         );
+        error
     }
-    error
+    #[cfg(not(any(target_arch = "riscv32", target_arch = "riscv64")))]
+    {
+        let _ = (eid, arg0, arg1);
+        unimplemented!("not RISC-V instruction set architecture")
+    }
 }
 
 #[inline(always)]
 fn sbi_call_legacy_3(eid: usize, arg0: usize, arg1: usize, arg2: usize) -> usize {
-    let error;
+    #[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))]
     unsafe {
+        let error;
         core::arch::asm!(
             "ecall",
             in("a7") eid,
@@ -139,14 +158,20 @@ fn sbi_call_legacy_3(eid: usize, arg0: usize, arg1: usize, arg2: usize) -> usize
             in("a1") arg1,
             in("a2") arg2,
         );
+        error
     }
-    error
+    #[cfg(not(any(target_arch = "riscv32", target_arch = "riscv64")))]
+    {
+        let _ = (eid, arg0, arg1, arg2);
+        unimplemented!("not RISC-V instruction set architecture")
+    }
 }
 
 #[inline(always)]
 fn sbi_call_legacy_4(eid: usize, arg0: usize, arg1: usize, arg2: usize, arg3: usize) -> usize {
-    let error;
+    #[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))]
     unsafe {
+        let error;
         core::arch::asm!(
             "ecall",
             in("a7") eid,
@@ -155,6 +180,11 @@ fn sbi_call_legacy_4(eid: usize, arg0: usize, arg1: usize, arg2: usize, arg3: us
             in("a2") arg2,
             in("a3") arg3,
         );
+        error
     }
-    error
+    #[cfg(not(any(target_arch = "riscv32", target_arch = "riscv64")))]
+    {
+        let _ = (eid, arg0, arg1, arg2, arg3);
+        unimplemented!("not RISC-V instruction set architecture")
+    }
 }


### PR DESCRIPTION
这样可以使得添加了该项目的crates在编译平台（比如x86）上运行不依赖SBI的单元测试，而不需要额外编写其他代码。